### PR TITLE
Fix exception when ClientGet is called with default arguments

### DIFF
--- a/FCP2lib/Protocol/FCP2Protocol.cs
+++ b/FCP2lib/Protocol/FCP2Protocol.cs
@@ -1079,24 +1079,24 @@ namespace FCP2.Protocol
             ConnectIfNeeded();
 
             Write("ClientGet");
-            Write("IgnoreDS", ignoreDS.Value);
-            Write("DSonly", dsonly.Value);
+            if (ignoreDS.HasValue) Write("IgnoreDS", ignoreDS.Value);
+            if (dsonly.HasValue) Write("DSonly", dsonly.Value);
             Write("URI", uri);
             Write("Identifier", identifier);
-            Write("Verbosity", ((long)verbosity.Value));
-            Write("MaxSize", maxSize.Value);
-            Write("MaxTempSize", maxTempSize.Value);
-            Write("MaxRetries", maxRetries.Value);
-            Write("PriorityClass", ((long)priorityClass.Value));
+            if (verbosity.HasValue) Write("Verbosity", ((long)verbosity.Value));
+            if (maxSize.HasValue) Write("MaxSize", maxSize.Value);
+            if (maxTempSize.HasValue) Write("MaxTempSize", maxTempSize.Value);
+            if (maxRetries.HasValue) Write("MaxRetries", maxRetries.Value);
+            if (priorityClass.HasValue) Write("PriorityClass", ((long)priorityClass.Value));
             if (global.HasValue && global.Value && persistence.HasValue && persistence.Value == PersistenceEnum.Connection)
             {
                 throw new FormatException("Error, global request must be persistent");
             }
-            Write("Persistence", persistence);
-            Write("ClientToken", clientToken);
-            Write("Global", global.Value);
-            Write("BinaryBlob", binaryBlob.Value);
-            Write("AllowedMIMETypes", allowedMimeTypes);
+            if (persistence.HasValue) Write("Persistence", persistence);
+            if (clientToken != null) Write("ClientToken", clientToken);
+            if (global.HasValue) Write("Global", global.Value);
+            if (binaryBlob.HasValue) Write("BinaryBlob", binaryBlob.Value);
+            if (allowedMimeTypes != null) Write("AllowedMIMETypes", allowedMimeTypes);
 
             if (returnType != null)
             {


### PR DESCRIPTION
Don't pass null values for optional arguments to the node, let it use the defaults.
Fixes this exception:
```
System.InvalidOperationException was unhandled
  HResult=-2146233079
  Message=Nullable object must have a value.
  Source=mscorlib
  StackTrace:
       at System.ThrowHelper.ThrowInvalidOperationException(ExceptionResource resource)
       at System.Nullable`1.get_Value()
       at FCP2.Protocol.FCP2Protocol.ClientGet(String uri, String identifier, Nullable`1 ignoreDS, Nullable`1 dsonly, Nullable`1 verbosity, Nullable`1 maxSize, Nullable`1 maxTempSize, Nullable`1 maxRetries, Nullable`1 priorityClass, Nullable`1 persistence, String clientToken, Nullable`1 global, Nullable`1 binaryBlob, String allowedMimeTypes, Nullable`1 returnType, String filename, String tempFilename) in C:\Users\Admin\Documents\visual studio 2015\Projects\fcp2lib.NET\FCP2lib\Protocol\FCP2Protocol.cs:line 1082
```